### PR TITLE
Ensure compiles now and in the future.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ext/libigl"]
+	path = ext/libigl
+	url = https://github.com/libigl/libigl/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.8.6)
+project(SeamAwareDecimater)
 
 SET(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
@@ -15,7 +16,6 @@ add_definitions(-DIGL_NO_MOSEK)
 
 link_directories(
 	/usr/local/lib
-	/opt/local/lib
 	${EIGEN_DIRS}
 ) 
 

--- a/cmake/FindLIBIGL.cmake
+++ b/cmake/FindLIBIGL.cmake
@@ -11,6 +11,7 @@ FIND_PATH(LIBIGL_INCLUDE_DIR igl/readOBJ.h
    ${PROJECT_SOURCE_DIR}/../../include
    ${PROJECT_SOURCE_DIR}/../include
    ${PROJECT_SOURCE_DIR}/include
+   ${PROJECT_SOURCE_DIR}/ext/libigl/include
    ${PROJECT_SOURCE_DIR}/../libigl/include
    ${PROJECT_SOURCE_DIR}/../../libigl/include
    $ENV{LIBIGL}/include


### PR DESCRIPTION
Added libigl as a submodule because they are planning breaking changes.
Added project name in CMakeLists to silence a warning.
Removed /opt/local/lib as a library path, since that isn't where eigen would be installed by brew.